### PR TITLE
Add zone control only if zones > 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,7 +229,7 @@ function setupFromService(service) {
             // Only add zones control if more than 1 zone
             // Hack to always create a zone control
             // TODO: Remove if block
-            if (zones.length > 0) {
+            if (zones.length > 1) {
               for (var zone in zones) {
 
                 yamaha.getBasicInfo(zones[zone]).then(function(basicInfo) {


### PR DESCRIPTION
My AVR (RX-V475) has only one zone but I have always one redundant zone zone control for "Main" zone. I assumed this is a typo and this if statement should actually check if there is more than one zone before adding zone specific controls.