### PR TITLE
New config key 'zone_controllers_only_for'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ config.json
 - radio_presets - Create a switch for each radio preset, defaults to false ( true/false )
 - preset_num - Names the switch the number of the preset, defaults to false ( true/false ). Otherwise the name is the frequency. ( useful with Siri and Alexa )
 - zone - Zone name
+- zone_controllers_only_for - A list of zone names for which an accessory is to be created. If no value for this key is provided, then accessories for all available zones are created.
 
 Optional Properties:
 - party_switch - You can choose whether you need Party Mode Switch or not. "party_switch": "yes" if needed or don't add this property if you don't need the switch.

--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ function YamahaAVRPlatform(log, config) {
   this.partySwitch = config["party_switch"];
   //this.inputAccessories is nessesary for optional Inputs Switches
   this.inputAccessories = config["inputs_as_accessories"] || {};
+  this.zoneControllersOnlyFor = config["zone_controllers_only_for"] || null;
 }
 
 // Custom Characteristics and service...
@@ -231,7 +232,6 @@ function setupFromService(service) {
             // TODO: Remove if block
             if (zones.length > 0) {
               for (var zone in zones) {
-
                 yamaha.getBasicInfo(zones[zone]).then(function(basicInfo) {
                   if (basicInfo.getVolume() != -999) {
 
@@ -239,9 +239,11 @@ function setupFromService(service) {
                       function(zoneInfo) {
                         var z = Object.keys(zoneInfo.YAMAHA_AV)[1];
                         zoneName = zoneInfo.YAMAHA_AV[z][0].Config[0].Name[0].Zone[0];
-                        this.log("Adding zone controller for", zoneName);
-                        var accessory = new YamahaZone(this.log, this.config, zoneName, yamaha, sysConfig, z);
-                        accessories.push(accessory);
+                        if (this.zoneControllersOnlyFor == null || this.zoneControllersOnlyFor.includes(zoneName)) {
+                          this.log("Adding zone controller for", zoneName);
+                          var accessory = new YamahaZone(this.log, this.config, zoneName, yamaha, sysConfig, z);
+                          accessories.push(accessory);
+                        }
                       }.bind(this)
                     );
 


### PR DESCRIPTION
Hi

I added a new config key that allows to specify for which zones accessories should be created.  Perhaps you find this useful and want to pull it.

Ciao
Francesco