### PR TITLE
New config for renaming zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ sudo npm install -g homebridge-yamaha-home
 - preset_num - Names the switch the number of the preset, defaults to false ( true/false ). Otherwise the name is the frequency. ( useful with Siri and Alexa )
 - zone - Zone name
 - zone_controllers_only_for - A list of zone names for which an accessory is to be created. If no value for this key is provided, then accessories for all available zones are created.
+- zone_name_map - Pass an object with old zone name as key and new zone name as value. Useful to control zone names with older receviers, which don’t allow renaming zones.
 
 Optional Properties:
 - party_switch - You can choose whether you need Party Mode Switch or not. "party_switch": "yes" if needed or don't add this property if you don't need the switch.

--- a/index.js
+++ b/index.js
@@ -70,7 +70,6 @@ function YamahaAVRPlatform(log, config) {
   // this.inputAccessories is nessesary for optional Inputs Switches
   this.inputAccessories = config["inputs_as_accessories"] || {};
   this.zoneControllersOnlyFor = config["zone_controllers_only_for"] || null;
-  this.zoneNameMap = config["zone_name_map"] || {};
 }
 
 // Custom Characteristics and service...
@@ -566,6 +565,7 @@ function YamahaZone(log, config, name, yamaha, sysConfig, zone) {
   this.gapVolume = this.maxVolume - this.minVolume;
 
   this.zone = zone;
+  this.zoneNameMap = config["zone_name_map"] || {};
   this.name = this.zoneNameMap[name] || name;
 }
 

--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ function YamahaAVRPlatform(log, config) {
   // this.inputAccessories is nessesary for optional Inputs Switches
   this.inputAccessories = config["inputs_as_accessories"] || {};
   this.zoneControllersOnlyFor = config["zone_controllers_only_for"] || null;
+  this.zoneNameMap = config["zone_name_map"] || {};
 }
 
 // Custom Characteristics and service...
@@ -565,7 +566,7 @@ function YamahaZone(log, config, name, yamaha, sysConfig, zone) {
   this.gapVolume = this.maxVolume - this.minVolume;
 
   this.zone = zone;
-  this.name = name;
+  this.name = this.zoneNameMap[name] || name;
 }
 
 YamahaZone.prototype = {


### PR DESCRIPTION
Hi @NorthernMan54,

I have an old Yamaha receiver model (RX-V475), which does not allow renaming zones. So when I activate this plugin, my main zone appears as "Main" in Homekit. I know that it’s possible to rename devices in Homekit itself, but there are cases when those name changes get lost, e. g. after rebooting the network. So I was searching for a more permanent solution.

Within this pull request I added a simple optional map config, which allows to specify a custom name for each zone, if provided.

Example config (part):

```json
{ 
    "nozones": false,
    "zone_name_map": {
        "Main": "Yamaha Main"
    },
}
```

The "Main" zone now appears as "Yamaha Main" inside Homekit. 🥳

Would be glad if you'd merge this pull request, thank you!